### PR TITLE
include charCode when unicodeMapping missing

### DIFF
--- a/src/Encoding.ts
+++ b/src/Encoding.ts
@@ -35,7 +35,8 @@ class Encoding {
     const mapped = this.unicodeMappings[codePoint];
     if (!mapped) {
       const str = String.fromCharCode(codePoint);
-      const msg = `${this.name} cannot encode "${str}" (0x${codePoint.toString(16).padStart(2, '0')})`;
+      const charRef = ('000' + codePoint.toString(16)).slice(-4);
+      const msg = `${this.name} cannot encode "${str}" (0x${charRef})`;
       throw new Error(msg);
     }
     return { code: mapped[0], name: mapped[1] };

--- a/src/Encoding.ts
+++ b/src/Encoding.ts
@@ -35,7 +35,7 @@ class Encoding {
     const mapped = this.unicodeMappings[codePoint];
     if (!mapped) {
       const str = String.fromCharCode(codePoint);
-      const msg = `${this.name} cannot encode "${str}"`;
+      const msg = `${this.name} cannot encode "${str}" (0x${codePoint.toString(16).padStart(2, '0')})`;
       throw new Error(msg);
     }
     return { code: mapped[0], name: mapped[1] };


### PR DESCRIPTION
As per the comment https://github.com/Hopding/pdf-lib/issues/277#issuecomment-645814156

If a character is not mapped in the unicodeMappings dictionary, and that character is a control character, the console logs `cannot encode "" `, which is not as helpful an error message as it might be. This simple change will make searching for the offending character(s) much easier for the developer.