### PR TITLE
Bump pako from 1.0.11 to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://github.com/Hopding/standard-fonts",
   "dependencies": {
-    "pako": "^1.0.6"
+    "pako": "^2.0.3"
   },
   "devDependencies": {
     "@types/mz": "^0.0.32",

--- a/yarn.lock
+++ b/yarn.lock
@@ -543,10 +543,10 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-pako@^1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.7.tgz#2473439021b57f1516c82f58be7275ad8ef1bb27"
-  integrity sha512-3HNK5tW4x8o5mO8RuHZp3Ydw9icZXx0RANAOMzlMzx7LVXhMJ4mo3MOBpzyd7r/+RUu8BmndP47LXT+vzjtWcQ==
+pako@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.3.tgz#cdf475e31b678565251406de9e759196a0ea7a43"
+  integrity sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==
 
 parse-glob@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Hi,
referring to [#863](https://github.com/Hopding/pdf-lib/pull/863), and taking into account that types for pako did not change you can bump dependency. I was not able to test if lib still builds.